### PR TITLE
use custom domain for dynamic links

### DIFF
--- a/src/authentication-service.ts
+++ b/src/authentication-service.ts
@@ -158,7 +158,7 @@ export default class AuthenticationService {
         flatbuffers.createLong(0, 0)
       )
     )
-    
+
     let msg = message.SelfMessaging.Message.endMessage(builder)
 
     builder.finish(msg)
@@ -199,11 +199,11 @@ export default class AuthenticationService {
     let encodedBody = this.jwt.encode(body)
 
     if (this.env === '') {
-      return `https://joinself.page.link/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app`
+      return `https://links.joinself.com/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app`
     } else if (this.env === 'development') {
-      return `https://joinself.page.link/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app.dev`
+      return `https://links.joinself.com/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app.dev`
     }
-    return `https://joinself.page.link/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app.${this.env}`
+    return `https://${this.env}.links.joinself.com/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app.${this.env}`
   }
 
   /**

--- a/src/facts-service.ts
+++ b/src/facts-service.ts
@@ -263,11 +263,11 @@ export default class FactsService {
     let encodedBody = this.jwt.encode(body)
 
     if (this.env === '') {
-      return `https://joinself.page.link/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app`
+      return `https://links.joinself.com/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app`
     } else if (this.env === 'development') {
-      return `https://joinself.page.link/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app.dev`
+      return `https://links.joinself.com/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app.dev`
     }
-    return `https://joinself.page.link/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app.${this.env}`
+    return `https://${this.env}.links.joinself.com/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app.${this.env}`
   }
 
   /**


### PR DESCRIPTION
Firebase Dynamic Links do not support using the same URL prefix for multiple iOS apps/targets contained in the same Firebase project. 

### Solution: Using multiple (sub)domains

It works, if each iOS app uses its own (sub)domain for dynamic links. For instance, instead of using only pets.page.link for all targets, use cats.page.link for your first app target and dogs.page.link for your second app target. The crucial requirement for this is that each of your target's Associated Domains Entitlement contains only the (sub)domain(s) it should listen to.

### Custom domain

Additionally we're moving to custom sub-domains based on `joinself.com` to manage all dynamic links.

This will require changes both on `ios` and `android`

[Reference](https://stackoverflow.com/questions/41582867/firebase-dynamic-links-is-not-working-for-different-target-in-same-project-in-io/61208739#61208739)
