### PR TITLE
Add expiration to attestations

### DIFF
--- a/src/facts-service.ts
+++ b/src/facts-service.ts
@@ -137,6 +137,7 @@ export default class FactsService {
         sub: selfid,
         iss: this.requester.jwt.appID,
         iat: iat.toISOString(),
+        exp: exp.toISOString(),
         source: facts[i]['source'],
         verified: true,
         facts: [ facts[i] ] }


### PR DESCRIPTION
When facts are shared to a third party user, the expiration data can't be inferred from the fact enveloping it. This PR adds the expiration date to the attestation itself.