### PR TITLE
Revert "Bump libsodium-wrappers-sumo from 0.7.9 to 0.7.10 (#168)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9459,9 +9459,9 @@
       }
     },
     "node_modules/libsodium-wrappers-sumo": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.10.tgz",
-      "integrity": "sha512-1noz8Mcl/LUzO/iSO/FJzoJyIaPwxl+/+E4CoTIXtsPiEEXQx2sxalmrVWxteLpynqgX0ASo28ChB9NEVRh0Pg==",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.9.tgz",
+      "integrity": "sha512-XLgLkqY973PngrRElbjOH0y7bJKYEfMWVpWPmW5iuhBjO6zXvHYQWtN52MVEeie/h98ZXN1Aw9BE+GzxQVAfLg==",
       "dev": true,
       "dependencies": {
         "libsodium-sumo": "^0.7.0"
@@ -26402,9 +26402,9 @@
       }
     },
     "libsodium-wrappers-sumo": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.10.tgz",
-      "integrity": "sha512-1noz8Mcl/LUzO/iSO/FJzoJyIaPwxl+/+E4CoTIXtsPiEEXQx2sxalmrVWxteLpynqgX0ASo28ChB9NEVRh0Pg==",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.9.tgz",
+      "integrity": "sha512-XLgLkqY973PngrRElbjOH0y7bJKYEfMWVpWPmW5iuhBjO6zXvHYQWtN52MVEeie/h98ZXN1Aw9BE+GzxQVAfLg==",
       "dev": true,
       "requires": {
         "libsodium-sumo": "^0.7.0"


### PR DESCRIPTION
This reverts commit e9da34c9b95d9303d7919dc75f8b53a017da135d. causing a problem on encryption