### PR TITLE
Support redirections

### DIFF
--- a/src/authentication-service.ts
+++ b/src/authentication-service.ts
@@ -64,7 +64,7 @@ export default class AuthenticationService {
 
   /**
    * Generates a deep link url so you can authenticate your users with a simple link.
-   * @param callback the url you want your users to be sent back after authentication.
+   * @param callback the redirection identifier you'll be redirected to if the app is not installed.
    * @param opts optional parameters like selfid or conversation id
    */
   generateDeepLink(callback: string, opts?: { selfid?: string; cid?: string }): string {

--- a/src/chat-service.ts
+++ b/src/chat-service.ts
@@ -253,13 +253,7 @@ export default class ChatService {
   generateConnectionDeepLink(callback: string, opts?: { exp?: number }): string {
     let body = this.buildConnectionRequest(opts)
     let encodedBody = this.is.jwt.encode(body)
-
-    if (this.env === '') {
-      return `https://links.joinself.com/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app`
-    } else if (this.env === 'development') {
-      return `https://links.joinself.com/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app.dev`
-    }
-    return `https://${this.env}.links.joinself.com/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app.${this.env}`
+    return this.ms.buildDynamicLink(encodedBody, this.env, callback)
   }
 
   private buildConnectionRequest(opts?: { exp?: number }): string {

--- a/src/facts-service.ts
+++ b/src/facts-service.ts
@@ -82,7 +82,7 @@ export default class FactsService {
 
   /**
    * Generates a deep link url so you can request facts with a simple link.
-   * @param callback the url you want your users to be sent back after authentication.
+   * @param callback the redirection identifier you'll be redirected to if the app is not installed.
    * @param facts an array with the facts you're requesting.
    * @param opts optional parameters like selfid or conversation id
    */

--- a/src/messaging-service.ts
+++ b/src/messaging-service.ts
@@ -372,4 +372,20 @@ export default class MessagingService {
 
     return builder.asUint8Array()
   }
+
+  buildDynamicLink(encodedBody: string, env: string, callback: string): string{
+    let baseURL = `https://${env}.links.joinself.com`
+    let portalURL = `https://developer.${env}.joinself.com`
+    let apn = `com.joinself.app.${env}`
+
+    if (env === '' || env === 'development') {
+      baseURL = "https://links.joinself.com"
+      portalURL = "https://developer.joinself.com"
+      apn = "com.joinself.app"
+      if (env === 'development') {
+        apn = "com.joinself.app.dev"
+      }
+    }
+    return `${baseURL}?link=${portalURL}/callback/${callback}%3Fqr=${encodedBody}&apn=${apn}`
+  }
 }

--- a/src/requester.ts
+++ b/src/requester.ts
@@ -268,7 +268,7 @@ export default class Requester {
 
   /**
    * Generates a deep link url so you can request facts with a simple link.
-   * @param callback the url you want your users to be sent back after authentication.
+   * @param callback the redirection identifier you'll be redirected to if the app is not installed.
    * @param facts an array with the facts you're requesting.
    * @param opts optional parameters like selfid or conversation id
    */
@@ -281,13 +281,19 @@ export default class Requester {
     let selfid = options.selfid ? options.selfid : '-'
     let body = this.jwt.toSignedJson(this.buildRequest(selfid, facts, options))
     let encodedBody = this.jwt.encode(body)
+    let baseURL = `https://${this.env}.links.joinself.com`
+    let portalURL = `https://developer.${this.env}.joinself.com`
+    let apn = `com.joinself.app.${this.env}`
 
-    if (this.env === '') {
-      return `https://links.joinself.com/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app`
-    } else if (this.env === 'development') {
-      return `https://links.joinself.com/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app.dev`
+    if (this.env === '' || this.env === 'development') {
+      baseURL = "https://links.joinself.com"
+      portalURL = "https://developer.joinself.com"
+      apn = "com.joinself.app"
+      if (this.env === 'development') {
+        apn = "com.joinself.app.dev"
+      }
     }
-    return `https://${this.env}.links.joinself.com/?link=${callback}%3Fqr=${encodedBody}&apn=com.joinself.app.${this.env}`
+    return `${baseURL}?link=${portalURL}/callback/${callback}%3Fqr=${encodedBody}&apn=${apn}`
   }
 
   /**

--- a/src/requester.ts
+++ b/src/requester.ts
@@ -281,19 +281,7 @@ export default class Requester {
     let selfid = options.selfid ? options.selfid : '-'
     let body = this.jwt.toSignedJson(this.buildRequest(selfid, facts, options))
     let encodedBody = this.jwt.encode(body)
-    let baseURL = `https://${this.env}.links.joinself.com`
-    let portalURL = `https://developer.${this.env}.joinself.com`
-    let apn = `com.joinself.app.${this.env}`
-
-    if (this.env === '' || this.env === 'development') {
-      baseURL = "https://links.joinself.com"
-      portalURL = "https://developer.joinself.com"
-      apn = "com.joinself.app"
-      if (this.env === 'development') {
-        apn = "com.joinself.app.dev"
-      }
-    }
-    return `${baseURL}?link=${portalURL}/callback/${callback}%3Fqr=${encodedBody}&apn=${apn}`
+    return this.messagingService.buildDynamicLink(encodedBody, this.env, callback)
   }
 
   /**

--- a/test/authentication-service.test.ts
+++ b/test/authentication-service.test.ts
@@ -257,12 +257,12 @@ describe('AuthenticationService', () => {
 
   describe('AuthenticationService::generateDeepLink', () => {
     it('happy path', async () => {
-      let callback = 'http://callback.com'
+      let callback = '0x000x'
       let link = auth.generateDeepLink(callback)
       const url = new URL(link)
 
       let callbackURL = new URL(url.searchParams.get('link'))
-      expect(callbackURL.host).toEqual('callback.com')
+      expect(callbackURL.host).toEqual('developer.test.joinself.com')
 
       let ciphertext = JSON.parse(
         Buffer.from(callbackURL.searchParams.get('qr'), 'base64').toString()
@@ -276,12 +276,12 @@ describe('AuthenticationService', () => {
     })
 
     it('happy path with custom options', async () => {
-      let callback = 'http://callback.com'
+      let callback = '0x000x'
       let link = auth.generateDeepLink(callback, { selfid: 'selfid', cid: 'cid' })
       const url = new URL(link)
 
       let callbackURL = new URL(url.searchParams.get('link'))
-      expect(callbackURL.host).toEqual('callback.com')
+      expect(callbackURL.host).toEqual('developer.test.joinself.com')
 
       let ciphertext = JSON.parse(
         Buffer.from(callbackURL.searchParams.get('qr'), 'base64').toString()
@@ -296,13 +296,13 @@ describe('AuthenticationService', () => {
     })
 
     it('happy path for development', async () => {
-      let callback = 'http://callback.com'
+      let callback = '0x000x'
       r.env = 'development'
       let link = auth.generateDeepLink(callback, { selfid: 'selfid', cid: 'cid' })
       const url = new URL(link)
 
       let callbackURL = new URL(url.searchParams.get('link'))
-      expect(callbackURL.host).toEqual('callback.com')
+      expect(callbackURL.host).toEqual('developer.joinself.com')
 
       let ciphertext = JSON.parse(
         Buffer.from(callbackURL.searchParams.get('qr'), 'base64').toString()
@@ -317,13 +317,13 @@ describe('AuthenticationService', () => {
     })
 
     it('happy path for production', async () => {
-      let callback = 'http://callback.com'
+      let callback = '0x000x'
       r.env = ''
       let link = auth.generateDeepLink(callback, { selfid: 'selfid', cid: 'cid' })
       const url = new URL(link)
 
       let callbackURL = new URL(url.searchParams.get('link'))
-      expect(callbackURL.host).toEqual('callback.com')
+      expect(callbackURL.host).toEqual('developer.joinself.com')
 
       let ciphertext = JSON.parse(
         Buffer.from(callbackURL.searchParams.get('qr'), 'base64').toString()

--- a/test/facts-service.test.ts
+++ b/test/facts-service.test.ts
@@ -283,12 +283,12 @@ describe('FactsService', () => {
 
   describe('FactsService::generateDeepLink', () => {
     it('happy path', async () => {
-      let callback = 'http://callback.com'
+      let callback = '0x000x'
       let link = fs.generateDeepLink(callback, [{ fact: 'phone_number' }])
       const url = new URL(link)
 
       let callbackURL = new URL(url.searchParams.get('link'))
-      expect(callbackURL.host).toEqual('callback.com')
+      expect(callbackURL.host).toEqual('developer.test.joinself.com')
 
       let ciphertext = JSON.parse(
         Buffer.from(callbackURL.searchParams.get('qr'), 'base64').toString()
@@ -303,7 +303,7 @@ describe('FactsService', () => {
     })
 
     it('happy path with custom options', async () => {
-      let callback = 'http://callback.com'
+      let callback = '0x000x'
       let link = fs.generateDeepLink(callback, [{ fact: 'phone_number' }], {
         cid: 'cid',
         selfid: 'selfid'
@@ -311,7 +311,7 @@ describe('FactsService', () => {
       const url = new URL(link)
 
       let callbackURL = new URL(url.searchParams.get('link'))
-      expect(callbackURL.host).toEqual('callback.com')
+      expect(callbackURL.host).toEqual('developer.test.joinself.com')
 
       let ciphertext = JSON.parse(
         Buffer.from(callbackURL.searchParams.get('qr'), 'base64').toString()
@@ -327,13 +327,13 @@ describe('FactsService', () => {
     })
 
     it('happy path for development', async () => {
-      let callback = 'http://callback.com'
+      let callback = '0x000x'
       r.env = 'development'
       let link = fs.generateDeepLink(callback, [{ fact: 'phone_number' }])
       const url = new URL(link)
 
       let callbackURL = new URL(url.searchParams.get('link'))
-      expect(callbackURL.host).toEqual('callback.com')
+      expect(callbackURL.host).toEqual('developer.joinself.com')
 
       let ciphertext = JSON.parse(
         Buffer.from(callbackURL.searchParams.get('qr'), 'base64').toString()
@@ -348,13 +348,13 @@ describe('FactsService', () => {
     })
 
     it('happy path for production', async () => {
-      let callback = 'http://callback.com'
+      let callback = '0x000x'
       r.env = ''
       let link = fs.generateDeepLink(callback, [{ fact: 'phone_number' }])
       const url = new URL(link)
 
       let callbackURL = new URL(url.searchParams.get('link'))
-      expect(callbackURL.host).toEqual('callback.com')
+      expect(callbackURL.host).toEqual('developer.joinself.com')
 
       let ciphertext = JSON.parse(
         Buffer.from(callbackURL.searchParams.get('qr'), 'base64').toString()


### PR DESCRIPTION
Dynamic link redirections will be managed through the developer portal from now on

This means from now on, a developer must create a redirection for an app, and use the generated unique identifier with the helpers generating dynamic links on the sdks.