### PR TITLE
Refactor: Use Crypto package for UUID's instead of uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/libsodium-wrappers": "^0.7.9",
-        "@types/uuid": "^8.3.0",
         "axios": ">=0.24.0",
         "eslint": "^7.3.2",
         "flatbuffers": "^2.0.3",
@@ -26,7 +25,6 @@
         "string-width": "^5.0.1",
         "text-encoding": "^0.7.0",
         "ts-protoc-gen": "^0.15.0",
-        "uuid": "^8.3.2",
         "webpack-dev-server": "^4.5.0",
         "websocket": "^1.0.33",
         "ws": "^8.3.0"
@@ -2817,11 +2815,6 @@
       "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
       "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==",
       "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "node_modules/@types/yargs": {
       "version": "15.0.13",
@@ -18242,6 +18235,8 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -21216,11 +21211,6 @@
       "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
       "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==",
       "dev": true
-    },
-    "@types/uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -33023,7 +33013,9 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self-sdk",
-  "type": "mod",
+  "type": "module",
   "version": "0.0.66",
   "description": "",
   "keywords": [],
@@ -127,7 +127,6 @@
   },
   "dependencies": {
     "@types/libsodium-wrappers": "^0.7.9",
-    "@types/uuid": "^8.3.0",
     "axios": ">=0.24.0",
     "eslint": "^7.3.2",
     "flatbuffers": "^2.0.3",
@@ -143,7 +142,6 @@
     "string-width": "^5.0.1",
     "text-encoding": "^0.7.0",
     "ts-protoc-gen": "^0.15.0",
-    "uuid": "^8.3.2",
     "webpack-dev-server": "^4.5.0",
     "websocket": "^1.0.33",
     "ws": "^8.3.0"

--- a/src/chat-service.ts
+++ b/src/chat-service.ts
@@ -7,9 +7,7 @@ import { ChatMessage } from './chat-message';
 import { FileObject } from './chat-object';
 import { ChatGroup } from './chat-group';
 import { ErrorCorrectLevel, QRCode } from 'qrcode-generator-ts';
-import { v4 as uuidv4 } from 'uuid';
-import { Hash } from 'crypto';
-
+import { randomUUID as uuidv4, Hash } from 'crypto';
 
 export default class ChatService {
   is: IdentityService

--- a/src/chat-service.ts
+++ b/src/chat-service.ts
@@ -7,7 +7,7 @@ import { ChatMessage } from './chat-message';
 import { FileObject } from './chat-object';
 import { ChatGroup } from './chat-group';
 import { ErrorCorrectLevel, QRCode } from 'qrcode-generator-ts';
-import { randomUUID as uuidv4, Hash } from 'crypto';
+import { randomUUID as uuidv4 } from 'crypto';
 
 export default class ChatService {
   is: IdentityService

--- a/src/docs-service.ts
+++ b/src/docs-service.ts
@@ -1,6 +1,6 @@
 // Copyright 2020 Self Group Ltd. All Rights Reserved.
 
-import { v4 as uuidv4 } from 'uuid'
+import { randomUUID as uuidv4 } from 'crypto'
 import MessagingService from './messaging-service';
 import { logging, Logger } from './logging';
 import { FileObject } from './chat-object';

--- a/src/facts-service.ts
+++ b/src/facts-service.ts
@@ -1,6 +1,6 @@
 // Copyright 2020 Self Group Ltd. All Rights Reserved.
 
-import { v4 as uuidv4 } from 'uuid'
+import { randomUUID as uuidv4 } from 'crypto'
 
 import Fact from './fact'
 import FactResponse from './fact-response'

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -1,6 +1,6 @@
 // Copyright 2020 Self Group Ltd. All Rights Reserved.
 
-import { v4 as uuidv4 } from 'uuid'
+import { randomUUID as uuidv4 } from 'crypto'
 import { NTPClient } from 'ntpclient'
 import { logging, Logger } from './logging'
 import { IOManager } from './storage'

--- a/src/messaging-service.ts
+++ b/src/messaging-service.ts
@@ -1,7 +1,7 @@
 // Copyright 2020 Self Group Ltd. All Rights Reserved.
 
 import Jwt from './jwt'
-import { v4 as uuidv4 } from 'uuid'
+import { randomUUID as uuidv4 } from 'crypto'
 
 import IdentityService from './identity-service'
 import Messaging from './messaging'

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -14,7 +14,7 @@ import FactResponse from './fact-response'
 
 import * as fs from 'fs'
 import { openStdin } from 'process'
-import { v4 as uuidv4 } from 'uuid'
+import { randomUUID as uuidv4 } from 'crypto'
 import * as flatbuffers from 'flatbuffers'
 import { Identity, App } from './identity-service'
 import { logging, Logger } from './logging'

--- a/src/requester.ts
+++ b/src/requester.ts
@@ -1,6 +1,6 @@
 // Copyright 2020 Self Group Ltd. All Rights Reserved.
 
-import { v4 as uuidv4 } from 'uuid'
+import { randomUUID as uuidv4 } from 'crypto'
 import {
   QRCode,
   ErrorCorrectLevel,


### PR DESCRIPTION
NodeJS Contains a built-in randomUUID function which generates v4 UUID's meaning we can remove the UUID dependency.