### PR TITLE
Add 'public' field to Chat Message Attached Objects

### DIFF
--- a/src/chat-object.ts
+++ b/src/chat-object.ts
@@ -103,7 +103,8 @@ export class FileObject {
       link: this.link,
       key: this.key,
       mime: this.mime,
-      expires: this.expires
+      expires: this.expires,
+      public: (this.key == "")
     }
   }
 


### PR DESCRIPTION
### Description:
In order to accommodate the recent changes in the mobile app, we've introduced a new field `public` in the payload for chat message attached objects. This field is a boolean that will help us determine if the attached file object is public or not.

